### PR TITLE
 community: change model to a required argument, align batch_size

### DIFF
--- a/libs/community/langchain_community/embeddings/voyageai.py
+++ b/libs/community/langchain_community/embeddings/voyageai.py
@@ -115,13 +115,21 @@ class VoyageEmbeddings(BaseModel, Embeddings):
     def _get_embeddings(
         self,
         texts: List[str],
+        model: str,
         batch_size: Optional[int] = None,
         input_type: Optional[str] = None,
     ) -> List[List[float]]:
         embeddings: List[List[float]] = []
 
+        self.model = model
+
         if batch_size is None:
             batch_size = self.batch_size
+        else:
+            if self.model in ["voyage-2", "voyage-02"]:
+                batch_size = 72
+            else:
+                batch_size = 7
 
         if self.show_progress_bar:
             try:


### PR DESCRIPTION
 - Change model to a required argument
 - Change the default batch size to 72 for model "voyage-2"/"voyage-02", and to 7 for all other models. (However, still allow the user to specify batch size)
 
